### PR TITLE
add the three include headers to fix the compile issues in the WSL environment

### DIFF
--- a/src/b_tree/b_tree_manager.cpp
+++ b/src/b_tree/b_tree_manager.cpp
@@ -5,10 +5,11 @@
 #include <chrono>
 #include <cstdio>
 #include <fstream>
-#include <sstream>  // Add this line
+#include <sstream> 
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <iomanip>
 
 #include "../include/common/config.h"
 #include "b_tree_page.h"

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -9,6 +9,7 @@
 #include <fstream>     // for reading and writing files
 #include <set>         // for using set to track found keys
 #include <sstream>     // for using stringstream to create filenames
+#include <algorithm>
 
 #include "b_tree/b_tree.h"
 #include "b_tree/b_tree_manager.h"

--- a/src/include/common/config.h
+++ b/src/include/common/config.h
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <climits> // INT_MAX
 
 using frame_id_t = int32_t;  // frame id type
 using page_id_t = int32_t;   // page id type


### PR DESCRIPTION
1. Include <algorithm>: Fixes std::sort is not recognized.
2. Include <climits>: Fixes INT_MAX and INT_MIN are not declared.
3. Include <iomanip>: Fixes std::setfill and std::setw are not recognized.