### PR TITLE
Implement the design of the Bloom filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ CFILES = src/main.cpp \
          src/b_tree/b_tree_page.cpp \
 		 src/b_tree/b_tree_manager.cpp \
          src/sst.cpp \
+         src/bloom_filter/bloom_filter.cpp
         #  test/tests.cpp
 
 HFILES = src/avl_tree.h \
@@ -23,6 +24,7 @@ HFILES = src/avl_tree.h \
 		 src/b_tree/b_tree_manager.h \
 		 src/include/common/config.h \
          src/sst.h \
+         src/bloom_filter/bloom_filter.h
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,6 @@ HFILES = src/avl_tree.h \
          src/sst.h \
          src/bloom_filter/bloom_filter.h
 
-
-
 main: $(CFILES) $(HFILES)
 	$(CC) $(CFLAGS) -o main $(CFILES)
 
@@ -36,6 +34,7 @@ tests: $(CFILES)
 
 clean:
 	rm -f main tests
+	rm -f ../*.sst ../*.filter
 
 test: tests
 	./tests

--- a/src/bloom_filter/bloom_filter.cpp
+++ b/src/bloom_filter/bloom_filter.cpp
@@ -1,0 +1,55 @@
+#include "bloom_filter.h"
+#include <fstream>
+#include <functional>
+
+// Constructor: Initializes the Bloom filter with a given number of bits and hash functions.
+BloomFilter::BloomFilter(size_t num_bits, size_t num_hashes)
+    : bit_array_(num_bits, false), num_hashes_(num_hashes), num_bits_(num_bits) {}
+
+// Inserts a key into the Bloom filter by setting the corresponding bits.
+void BloomFilter::Insert(int key) {
+  for (size_t i = 0; i < num_hashes_; ++i) {
+    size_t hash = Hash(key, i) % num_bits_;
+    bit_array_[hash] = true;
+  }
+}
+
+// Checks if a key might exist in the Bloom filter (returns false if definitely not present).
+bool BloomFilter::MayContain(int key) const {
+  for (size_t i = 0; i < num_hashes_; ++i) {
+    size_t hash = Hash(key, i) % num_bits_;
+    if (!bit_array_[hash]) return false;
+  }
+  return true;
+}
+
+// Hash function: Computes a hash value for the given key and seed.
+size_t BloomFilter::Hash(int key, int seed) const {
+  std::hash<int> hasher;
+  return hasher(key ^ seed);
+}
+
+// Serializes the Bloom filter to a binary file for persistent storage.
+void BloomFilter::SerializeToDisk(const std::string &filename) const {
+  std::ofstream out_file(filename, std::ios::binary);
+  out_file.write(reinterpret_cast<const char *>(&num_bits_), sizeof(num_bits_));
+  out_file.write(reinterpret_cast<const char *>(&num_hashes_), sizeof(num_hashes_));
+  for (bool bit : bit_array_) {
+    out_file.write(reinterpret_cast<const char *>(&bit), sizeof(bit));
+  }
+  out_file.close();
+}
+
+// Deserializes the Bloom filter from a binary file and restores its state.
+void BloomFilter::DeserializeFromDisk(const std::string &filename) {
+  std::ifstream in_file(filename, std::ios::binary);
+  in_file.read(reinterpret_cast<char *>(&num_bits_), sizeof(num_bits_));
+  in_file.read(reinterpret_cast<char *>(&num_hashes_), sizeof(num_hashes_));
+  bit_array_.resize(num_bits_);
+  for (size_t i = 0; i < num_bits_; ++i) {
+    bool bit;
+    in_file.read(reinterpret_cast<char *>(&bit), sizeof(bit));
+    bit_array_[i] = bit;
+  }
+  in_file.close();
+}

--- a/src/bloom_filter/bloom_filter.cpp
+++ b/src/bloom_filter/bloom_filter.cpp
@@ -53,3 +53,13 @@ void BloomFilter::DeserializeFromDisk(const std::string &filename) {
   }
   in_file.close();
 }
+
+void BloomFilter::Union(const BloomFilter& other) {
+    if (num_bits_ != other.num_bits_ || num_hashes_ != other.num_hashes_) {
+        throw std::invalid_argument("Cannot union Bloom filters with different sizes or hash functions");
+    }
+
+    for (size_t i = 0; i < num_bits_; ++i) {
+        bit_array_[i] = bit_array_[i] || other.bit_array_[i];
+    }
+}

--- a/src/bloom_filter/bloom_filter.h
+++ b/src/bloom_filter/bloom_filter.h
@@ -1,0 +1,19 @@
+#pragma once // ensure the header file is included only once during compilation.
+#include <vector>
+#include <cmath>
+#include <string>
+
+class BloomFilter {
+ public:
+  BloomFilter(size_t num_bits, size_t num_hashes);
+  void Insert(int key);
+  bool MayContain(int key) const;
+  void SerializeToDisk(const std::string &filename) const;
+  void DeserializeFromDisk(const std::string &filename);
+
+ private:
+  size_t Hash(int key, int seed) const;
+  std::vector<bool> bit_array_;
+  size_t num_hashes_;
+  size_t num_bits_;
+};

--- a/src/bloom_filter/bloom_filter.h
+++ b/src/bloom_filter/bloom_filter.h
@@ -10,6 +10,7 @@ class BloomFilter {
   bool MayContain(int key) const;
   void SerializeToDisk(const std::string &filename) const;
   void DeserializeFromDisk(const std::string &filename);
+  void Union(const BloomFilter& other);
 
  private:
   size_t Hash(int key, int seed) const;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -15,9 +15,18 @@
 #include "b_tree/b_tree_manager.h"
 #include "bloom_filter/bloom_filter.h"
 
+// Define consistent Bloom filter configuration
+constexpr size_t BLOOM_FILTER_BITS = 1024;
+constexpr size_t BLOOM_FILTER_HASHES = 3;
+
 Database::Database(const std::string& name, size_t memtableSize)
     : db_name_(name), memtable_(memtableSize), is_open_(false)
 {
+    // Ensure the database name doesn't end with a slash
+    if (db_name_.back() == '/')
+    {
+        db_name_.pop_back();
+    }
 }
 
 void
@@ -34,7 +43,11 @@ Database::Open()
                db_name_.c_str());
         for (const auto& entry : std::filesystem::directory_iterator(db_name_))
         {
-            sst_files_.push_back(entry.path().string());
+            // Only include `.sst` files in the list
+            if (entry.path().extension() == ".sst")
+            {
+                sst_files_.push_back(entry.path().string());
+            }
         }
     }
     // Sort descending order to maintain LSM levels
@@ -92,7 +105,7 @@ Database::Get(int key)
         return -1;
     }
 
-    // check memtable first
+    // Check memtable first
     auto result = memtable_.Get(key);
     if (result == INT_MAX)
     {
@@ -108,7 +121,7 @@ Database::Get(int key)
     // Loop through SST files in reverse order
     for (auto it = sst_files_.rbegin(); it != sst_files_.rend(); ++it) {
         // Load the Bloom filter for the current SST file
-        BloomFilter bloom_filter(1024, 3);
+        BloomFilter bloom_filter(BLOOM_FILTER_BITS, BLOOM_FILTER_HASHES);
         bloom_filter.DeserializeFromDisk(*it + ".filter");
 
         // Check Bloom filter
@@ -127,7 +140,6 @@ Database::Get(int key)
         }
         if (result != -1 && result != INT_MAX)
         {
-            // print the filename it was found in
             printf("Found key %d in %s\n", key, it->c_str());
             return result;
         }
@@ -148,7 +160,7 @@ Database::Scan(int key1, int key2)
     std::vector<std::pair<int, int>> results;
     int range = key2 - key1;
 
-    // scan memory table first
+    // Scan memory table first
     auto memtable_results = memtable_.Scan(key1, key2);
     results.insert(results.end(), memtable_results.begin(), memtable_results.end());
     if (!memtable_results.empty()) {
@@ -156,14 +168,14 @@ Database::Scan(int key1, int key2)
                memtable_results.back().first);
     }
 
-    // use set to track found keys
+    // Use set to track found keys
     std::set<int> result_keys;
     for (const auto& r : results)
     {
         result_keys.insert(r.first);
     }
 
-    // return if we have all possible keys
+    // Return if we have all possible keys
     if (result_keys.size() > static_cast<size_t>(range))
     {
         return results;
@@ -175,7 +187,7 @@ Database::Scan(int key1, int key2)
         printf("Scanning SST file: %s\n", it->c_str());
 
         // Load the Bloom filter
-        BloomFilter bloom_filter(1024, 3);
+        BloomFilter bloom_filter(BLOOM_FILTER_BITS, BLOOM_FILTER_HASHES);
         bloom_filter.DeserializeFromDisk(*it + ".filter");
 
         bool may_contain = false;
@@ -185,7 +197,7 @@ Database::Scan(int key1, int key2)
                 may_contain = true;
                 break;
             }
-}
+        }
         if (!may_contain) {
             printf("SST file %s does not contain any keys in range (skipped using Bloom filter)\n", it->c_str());
             continue;
@@ -210,38 +222,38 @@ Database::Scan(int key1, int key2)
     return results;
 }
 
-/* Transform the memtable into an SST when it reaches capacity. */
 void
 Database::StoreMemtable()
 {
-    // Generate a unique filename for the SST file.
+    // Generate a unique filename for the SST file
     std::string filename = GenerateFileName();
     printf("Storing memtable to %s\n", filename.c_str());
 
-    // Get all kv pairs from the memtable in sorted order.
+    // Get all kv pairs from the memtable in sorted order
     auto result = memtable_.Scan(INT_MIN, INT_MAX);
     printf("Memtable size: %lu\n", result.size());
 
-    // Create a BloomFilter and populate it with keys from the memtable.
-    BloomFilter bloom_filter(result.size() * 10, 3); // 10 bits per entry, 3 hash functions
+    // Create a BloomFilter and populate it with keys from the memtable
+    BloomFilter bloom_filter(BLOOM_FILTER_BITS, BLOOM_FILTER_HASHES);
+
     for (const auto& pair : result) {
         bloom_filter.Insert(pair.first);
     }
 
-    // Serialize the BloomFilter to disk alongside the SST file.
+    // Serialize the BloomFilter to disk alongside the SST file
     bloom_filter.SerializeToDisk(filename + ".filter");
 
     // Use BTree to store the data
     BTree btree(result);
     btree.SaveBTreeToDisk(filename);
 
-    // Add the SST file to the list of SST files.
+    // Add the SST file to the list of SST files
     sst_files_.push_back(filename);
 
-    // Clear the memtable.
+    // Clear the memtable
     memtable_.Clear();
 
-    // Compact if necessary.
+    // Compact if necessary
     Compact();
 }
 
@@ -296,9 +308,28 @@ Database::Compact()
     std::string out_file = btm.Merge(filename2);
     std::filesystem::rename(out_file, db_name_ + "/" + out_file);
 
+    // Load Bloom filters for both files
+    BloomFilter bloom_filter1(BLOOM_FILTER_BITS, BLOOM_FILTER_HASHES);
+    bloom_filter1.DeserializeFromDisk(filename1 + ".filter");
+
+    BloomFilter bloom_filter2(BLOOM_FILTER_BITS, BLOOM_FILTER_HASHES);
+    bloom_filter2.DeserializeFromDisk(filename2 + ".filter");
+
+    // Create a new Bloom filter as the union of both
+    BloomFilter merged_filter(BLOOM_FILTER_BITS, BLOOM_FILTER_HASHES);
+    merged_filter.Union(bloom_filter1);
+    merged_filter.Union(bloom_filter2);
+
+    // Serialize the merged Bloom filter to disk
+    merged_filter.SerializeToDisk(out_file + ".filter");
+
+    printf("Merged Bloom filter for %s created and saved.\n", out_file.c_str());
+
     // remove the merged files
     std::filesystem::remove(filename1);
+    std::filesystem::remove(filename1 + ".filter");
     std::filesystem::remove(filename2);
+    std::filesystem::remove(filename2 + ".filter");
     sst_files_.pop_back();
     sst_files_.pop_back();
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -108,7 +108,7 @@ Database::Get(int key)
     // Loop through SST files in reverse order
     for (auto it = sst_files_.rbegin(); it != sst_files_.rend(); ++it) {
         // Load the Bloom filter for the current SST file
-        BloomFilter bloom_filter(1024, 3); // Use appropriate parameters
+        BloomFilter bloom_filter(1024, 3);
         bloom_filter.DeserializeFromDisk(*it + ".filter");
 
         // Check Bloom filter
@@ -175,17 +175,17 @@ Database::Scan(int key1, int key2)
         printf("Scanning SST file: %s\n", it->c_str());
 
         // Load the Bloom filter
-        BloomFilter bloom_filter(1024, 3); // Use appropriate parameters
+        BloomFilter bloom_filter(1024, 3);
         bloom_filter.DeserializeFromDisk(*it + ".filter");
 
-        // Check Bloom filter for the range
         bool may_contain = false;
-        for (int key = key1; key <= key2; ++key) {
+        int interval = std::max(1, (key2 - key1) / 1000);
+        for (int key = key1; key <= key2; key += interval) {
             if (bloom_filter.MayContain(key)) {
                 may_contain = true;
                 break;
             }
-        }
+}
         if (!may_contain) {
             printf("SST file %s does not contain any keys in range (skipped using Bloom filter)\n", it->c_str());
             continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,4 +39,7 @@ main()
     // get 1
     int result = db.Get(1);
     printf("Get 1: %d\n", result);
+    
+    // Test retrieval of an existing key
+    printf("Get 2: %d\n", db.Get(2));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,45 +1,42 @@
 #include <unistd.h>
-
 #include <filesystem>
-
 #include "database.h"
 #include "include/common/config.h"
 
-int
-main()
-{
+int main() {
     std::filesystem::remove_all("db");
     Database db("db", MEMTABLE_SIZE);
     db.Open();
 
-    // add key 1
+    // Add key 1
     db.Put(1, 10);
     printf("Put 1: 10\n");
 
     db.Put(2, 20);
-    // add 300000 keys
-    for (int i = 2; i < 7000000; i++)
-    {
+
+    // Add 300000 keys
+    for (int i = 2; i < 7000000; i++) {
         db.Put(i, i * 10);
     }
 
     printf("Get 1: %d\n", db.Get(1));
 
-    // delete 1
+    // Delete key 1
     db.Delete(1);
+    printf("Get 1 after delete: %d\n", db.Get(1));
 
-    printf("Get 1: %d\n", db.Get(1));
-
-    // add 300000 more keys
-    for (int i = 300002; i < 600002; i++)
-    {
+    // Add 300000 more keys
+    for (int i = 300002; i < 600002; i++) {
         db.Put(i, i * 10);
     }
 
-    // get 1
-    int result = db.Get(1);
-    printf("Get 1: %d\n", result);
-    
-    // Test retrieval of an existing key
+    // Retrieve existing key
     printf("Get 2: %d\n", db.Get(2));
+
+    // Retrieve deleted key
+    int result = db.Get(1);
+    printf("Get 1 after deletion: %d\n", result);
+
+    db.Close();
+    return 0;
 }

--- a/src/sst.cpp
+++ b/src/sst.cpp
@@ -1,4 +1,4 @@
-#include "sst.h"  // Includes bloom_filter.h via sst.h
+#include "sst.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/src/sst.cpp
+++ b/src/sst.cpp
@@ -1,4 +1,4 @@
-#include "sst.h"
+#include "sst.h"  // Includes bloom_filter.h via sst.h
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -7,76 +7,78 @@
 #include <fstream>
 #include <stdexcept>
 
-SSTable::SSTable(const std::string& path) : file_path(path)
-{
+SSTable::SSTable(const std::string& path) : file_path(path), bloom_filter(1024, 3) {
     struct stat buf;
-    if (stat(file_path.c_str(), &buf) != 0)
-    {
+    if (stat(file_path.c_str(), &buf) != 0) {
         throw std::runtime_error("Failed to stat SSTable file");
-    }
-    else
-    {
+    } else {
         // Dividing the file size by the size of one kv pair.
         num_entries = buf.st_size / (sizeof(int) * 2);
+
+        // Deserialize the Bloom filter associated with this SSTable
+        std::string bloom_filter_file = file_path + ".filter";
+        bloom_filter.DeserializeFromDisk(bloom_filter_file);
     }
 }
 
-int
-SSTable::readKey(int fd, off_t offset)
-{
+int SSTable::readKey(int fd, off_t offset) {
     int key;
-    if (pread(fd, &key, sizeof(int), offset) != sizeof(int))
-    {
+    if (pread(fd, &key, sizeof(int), offset) != sizeof(int)) {
         throw std::runtime_error("Failed to read key from SSTable");
     }
     return key;
 }
 
-int
-SSTable::readValue(int fd, off_t offset)
-{
+int SSTable::readValue(int fd, off_t offset) {
     int value;
-    if (pread(fd, &value, sizeof(int), offset) != sizeof(int))
-    {
+    if (pread(fd, &value, sizeof(int), offset) != sizeof(int)) {
         throw std::runtime_error("Failed to read value from SSTable");
     }
     return value;
 }
-
 /* Use a binary search to find the start of the range and continue with a scan
   until encounter a key key outside of the range. */
-std::vector<std::pair<int, int>>
-SSTable::scan(int key1, int key2)
-{
+std::vector<std::pair<int, int>> SSTable::scan(int key1, int key2) {
     std::vector<std::pair<int, int>> result;
 
-    int fd = open(file_path.c_str(), O_RDONLY);
+    // Check if any keys in the range might exist using the Bloom filter
+    bool may_contain = false;
+    for (int key = key1; key <= key2; ++key) {
+        if (bloom_filter.MayContain(key)) {
+            may_contain = true;
+            break;
+        }
+    }
+    if (!may_contain) {
+        printf("Bloom filter indicates no keys in range [%d, %d]\n", key1, key2);
+        return result;  // Skip scanning the SST
+    }
 
-    // Binary search to find the start of the range.
+    int fd = open(file_path.c_str(), O_RDONLY);
+    if (fd < 0) {
+        throw std::runtime_error("Failed to open SSTable file");
+    }
+
+    // Binary search to find the start of the range
     size_t left = 0;
     size_t right = num_entries - 1;
     size_t start_pos = num_entries;
 
-    while (left <= right)
-    {
+    while (left <= right) {
         size_t mid = (left + right) / 2;
         off_t ofs = mid * sizeof(int) * 2;
         int key = readKey(fd, ofs);
 
-        if (key < key1)
-        {
+        if (key < key1) {
             left = mid + 1;
-        }
-        else
-        {
+        } else {
             right = mid - 1;
             start_pos = mid;
         }
     }
 
     // Sequentially read from start position
-    for (size_t i = start_pos; i < num_entries; i++)
-    {
+    for (size_t i = start_pos; i < num_entries; i++) {
         off_t ofs = i * sizeof(int) * 2;
         int key = readKey(fd, ofs);
         if (key > key2) break;
@@ -85,38 +87,40 @@ SSTable::scan(int key1, int key2)
     }
 
     close(fd);
-
     return result;
 }
 
-/* Perform a binary search for an exact key match in SSTable. */
-int
-SSTable::get(int key)
-{
+int SSTable::get(int key) {
+    // Use the Bloom filter to check if the key might exist
+    static bool bloom_filter_message_printed = false;  // Flag to track message printing
+
+    // Check the Bloom filter before accessing the SST
+    if (!bloom_filter.MayContain(key)) {
+        if (!bloom_filter_message_printed) {
+            printf("Key %d is definitely not in %s (skipped using Bloom filter)\n", key, file_path.c_str());
+            bloom_filter_message_printed = true; 
+        }
+        return -1;  // Skip searching the SST
+    }
+
     int fd = open(file_path.c_str(), O_RDONLY);
     if (fd < 0) return -1;
 
     size_t left = 0;
     size_t right = num_entries - 1;
 
-    while (left <= right)
-    {
+    while (left <= right) {
         size_t mid = left + (right - left) / 2;
         off_t ofs = mid * sizeof(int) * 2;
         int mid_key = readKey(fd, ofs);
 
-        if (mid_key == key)
-        {
+        if (mid_key == key) {
             int value = readValue(fd, ofs + sizeof(int));
             close(fd);
             return value;
-        }
-        else if (mid_key < key)
-        {
+        } else if (mid_key < key) {
             left = mid + 1;
-        }
-        else
-        {
+        } else {
             right = mid - 1;
         }
     }
@@ -125,25 +129,24 @@ SSTable::get(int key)
     return -1;  // Key not found
 }
 
-/* Write key-value pairs to an SST file in binary format. */
-void
-SSTable::write(const std::string& filename,
-               const std::vector<std::pair<int, int>>& data)
-{
+void SSTable::write(const std::string& filename, const std::vector<std::pair<int, int>>& data) {
     std::ofstream outFile(filename, std::ios::binary);
-    if (!outFile.is_open())
-    {
+    if (!outFile.is_open()) {
         throw std::runtime_error("Failed to create SST file: " + filename);
     }
 
+    // Create a Bloom filter for the keys
+    BloomFilter bloom_filter(data.size() * 10, 3);  // 10 bits per entry, 3 hash functions
+
     // Write each key-value pair to the file
-    for (const auto& kv : data)
-    {
-        outFile.write(reinterpret_cast<const char*>(&kv.first),
-                      sizeof(kv.first));
-        outFile.write(reinterpret_cast<const char*>(&kv.second),
-                      sizeof(kv.second));
+    for (const auto& kv : data) {
+        outFile.write(reinterpret_cast<const char*>(&kv.first), sizeof(kv.first));
+        outFile.write(reinterpret_cast<const char*>(&kv.second), sizeof(kv.second));
+        bloom_filter.Insert(kv.first);  // Add the key to the Bloom filter
     }
 
     outFile.close();
+
+    // Serialize the Bloom filter to a separate file
+    bloom_filter.SerializeToDisk(filename + ".filter");
 }

--- a/src/sst.h
+++ b/src/sst.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "./bloom_filter/bloom_filter.h"
 
 /** Sorted String Table (SSTable) class.
  *
@@ -17,6 +18,7 @@ class SSTable
    private:
     std::string file_path;
     size_t num_entries;
+    BloomFilter bloom_filter; 
 
     int readKey(int fd, off_t offset);
     int readValue(int fd, off_t offset);


### PR DESCRIPTION
Implemented a Bloom filter for SSTables to enhance lookup efficiency. The Bloom filter is integrated into the Get workflow, allowing the system to skip file access when keys are guaranteed to be absent. Filters are created during SSTable writes, serialized for persistent storage, and deserialized for quick access during reads.