### PR TITLE
Add BTree tests, Format tests, Minor Bloom Filter tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,26 +11,26 @@ CFILES = src/main.cpp \
          src/memtable.cpp \
          src/b_tree/b_tree.cpp \
          src/b_tree/b_tree_page.cpp \
-		 src/b_tree/b_tree_manager.cpp \
+         src/b_tree/b_tree_manager.cpp \
          src/sst.cpp \
-         src/bloom_filter/bloom_filter.cpp
-        #  test/tests.cpp
+         src/bloom_filter/bloom_filter.cpp \
+         test/tests.cpp
 
 HFILES = src/avl_tree.h \
          src/database.h \
          src/memtable.h \
          src/b_tree/b_tree.h \
          src/b_tree/b_tree_page.h \
-		 src/b_tree/b_tree_manager.h \
-		 src/include/common/config.h \
+         src/b_tree/b_tree_manager.h \
+         src/include/common/config.h \
          src/sst.h \
          src/bloom_filter/bloom_filter.h
 
 main: $(CFILES) $(HFILES)
 	$(CC) $(CFLAGS) -o main $(CFILES)
 
-tests: $(CFILES)
-	$(CC) $(CFLAGS) -o tests test/tests.cpp src/avl_tree.cpp src/database.cpp src/memtable.cpp src/sst.cpp
+tests: $(CFILES) $(HFILES)
+	$(CC) $(CFLAGS) -o tests test/tests.cpp src/avl_tree.cpp src/database.cpp src/memtable.cpp src/sst.cpp src/b_tree/b_tree.cpp src/b_tree/b_tree_page.cpp src/b_tree/b_tree_manager.cpp src/bloom_filter/bloom_filter.cpp
 
 clean:
 	rm -f main tests

--- a/src/b_tree/b_tree.cpp
+++ b/src/b_tree/b_tree.cpp
@@ -103,3 +103,15 @@ BTree::SaveBTreeToDisk(const std::string& filename)
         leaf_page.WriteToDisk(filename);
     }
 }
+
+std::vector<BTreePage>
+BTree::GetLeafPages()
+{
+    return leaf_pages_;
+}
+
+std::vector<BTreePage>
+BTree::GetInternalPages()
+{
+    return internal_pages_;
+}

--- a/src/b_tree/b_tree.h
+++ b/src/b_tree/b_tree.h
@@ -17,6 +17,10 @@ class BTree
     // Save the BTree to disk for a given filename.
     void SaveBTreeToDisk(const std::string& filename);
 
+    // Testing Only:
+    std::vector<BTreePage> GetLeafPages();
+    std::vector<BTreePage> GetInternalPages();
+
    private:
     std::vector<BTreePage> internal_pages_;
     std::vector<BTreePage> leaf_pages_;

--- a/src/b_tree/b_tree_manager.cpp
+++ b/src/b_tree/b_tree_manager.cpp
@@ -5,11 +5,11 @@
 #include <chrono>
 #include <cstdio>
 #include <fstream>
-#include <sstream> 
+#include <iomanip>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <iomanip>
 
 #include "../include/common/config.h"
 #include "b_tree_page.h"
@@ -165,9 +165,6 @@ BTreeManager::TraverseRange(int start_key, int end_key) const
         }
     }
 
-    // print the max key of the leaf page
-    printf("Max key of leaf page: %d\n", page.GetMaxKey());
-
     // page is a leaf that contains the start key. Scan the range
     while (page.IsLeafPage())
     {
@@ -238,8 +235,6 @@ BTreeManager::MergeBTreeFromFile(const std::string &filename_to_merge)
     auto pairs_to_merge = page_to_merge.GetKeyValues();
     auto it1 = pairs.begin();
     auto it2 = pairs_to_merge.begin();
-
-    printf("Merging leaf pages\n");
 
     // Step 3: Merge the leaf pages into a new BTreePage
     while (page.IsLeafPage() && page_to_merge.IsLeafPage())
@@ -528,8 +523,6 @@ BTreeManager::DetermineMergeFilename(const std::string &filename1,
     std::stringstream new_filename;
     new_filename << "sst_" << std::setfill('0') << std::setw(4) << new_level
                  << "_" << (now_ms) << ".sst";
-
-    printf("Merging into %s\n", new_filename.str().c_str());
 
     return new_filename.str();
 }

--- a/src/b_tree/b_tree_manager.h
+++ b/src/b_tree/b_tree_manager.h
@@ -16,12 +16,15 @@ class BTreeManager
     // Merge the BTree with another BTree file, return output filename
     std::string Merge(const std::string& filename_to_merge);
 
+    // used for testing, would otherwise be private
+    BTreePage TraverseToKey(int key) const;
+
    private:
     std::string filename_;
     int largest_lsm_level_;
     bool remove_tombstones_;
     BTreePage ReadPageFromDisk(int page_id, const std::string& filename) const;
-    BTreePage TraverseToKey(int key) const;
+
     std::vector<std::pair<int, int>> TraverseRange(int start_key,
                                                    int end_key) const;
     std::string MergeBTreeFromFile(const std::string& filename_to_merge);

--- a/src/bloom_filter/bloom_filter.cpp
+++ b/src/bloom_filter/bloom_filter.cpp
@@ -1,65 +1,92 @@
 #include "bloom_filter.h"
+
 #include <fstream>
 #include <functional>
 
-// Constructor: Initializes the Bloom filter with a given number of bits and hash functions.
+// Constructor: Initializes the Bloom filter with a given number of bits and
+// hash functions.
 BloomFilter::BloomFilter(size_t num_bits, size_t num_hashes)
-    : bit_array_(num_bits, false), num_hashes_(num_hashes), num_bits_(num_bits) {}
-
-// Inserts a key into the Bloom filter by setting the corresponding bits.
-void BloomFilter::Insert(int key) {
-  for (size_t i = 0; i < num_hashes_; ++i) {
-    size_t hash = Hash(key, i) % num_bits_;
-    bit_array_[hash] = true;
-  }
+    : bit_array_(num_bits, false), num_hashes_(num_hashes), num_bits_(num_bits)
+{
 }
 
-// Checks if a key might exist in the Bloom filter (returns false if definitely not present).
-bool BloomFilter::MayContain(int key) const {
-  for (size_t i = 0; i < num_hashes_; ++i) {
-    size_t hash = Hash(key, i) % num_bits_;
-    if (!bit_array_[hash]) return false;
-  }
-  return true;
+// Inserts a key into the Bloom filter by setting the corresponding bits.
+void
+BloomFilter::Insert(int key)
+{
+    for (size_t i = 0; i < num_hashes_; ++i)
+    {
+        size_t hash = Hash(key, i) % num_bits_;
+        bit_array_[hash] = true;
+    }
+}
+
+// Checks if a key might exist in the Bloom filter (returns false if definitely
+// not present).
+bool
+BloomFilter::MayContain(int key) const
+{
+    for (size_t i = 0; i < num_hashes_; ++i)
+    {
+        size_t hash = Hash(key, i) % num_bits_;
+        if (!bit_array_[hash]) return false;
+    }
+    return true;
 }
 
 // Hash function: Computes a hash value for the given key and seed.
-size_t BloomFilter::Hash(int key, int seed) const {
-  std::hash<int> hasher;
-  return hasher(key ^ seed);
+size_t
+BloomFilter::Hash(int key, int seed) const
+{
+    std::hash<int> hasher;
+    return hasher(key ^ seed);
 }
 
 // Serializes the Bloom filter to a binary file for persistent storage.
-void BloomFilter::SerializeToDisk(const std::string &filename) const {
-  std::ofstream out_file(filename, std::ios::binary);
-  out_file.write(reinterpret_cast<const char *>(&num_bits_), sizeof(num_bits_));
-  out_file.write(reinterpret_cast<const char *>(&num_hashes_), sizeof(num_hashes_));
-  for (bool bit : bit_array_) {
-    out_file.write(reinterpret_cast<const char *>(&bit), sizeof(bit));
-  }
-  out_file.close();
+void
+BloomFilter::SerializeToDisk(const std::string &filename) const
+{
+    std::ofstream out_file(filename, std::ios::binary);
+    out_file.write(reinterpret_cast<const char *>(&num_bits_),
+                   sizeof(num_bits_));
+    out_file.write(reinterpret_cast<const char *>(&num_hashes_),
+                   sizeof(num_hashes_));
+    for (bool bit : bit_array_)
+    {
+        out_file.write(reinterpret_cast<const char *>(&bit), sizeof(bit));
+    }
+    out_file.close();
 }
 
 // Deserializes the Bloom filter from a binary file and restores its state.
-void BloomFilter::DeserializeFromDisk(const std::string &filename) {
-  std::ifstream in_file(filename, std::ios::binary);
-  in_file.read(reinterpret_cast<char *>(&num_bits_), sizeof(num_bits_));
-  in_file.read(reinterpret_cast<char *>(&num_hashes_), sizeof(num_hashes_));
-  bit_array_.resize(num_bits_);
-  for (size_t i = 0; i < num_bits_; ++i) {
-    bool bit;
-    in_file.read(reinterpret_cast<char *>(&bit), sizeof(bit));
-    bit_array_[i] = bit;
-  }
-  in_file.close();
+void
+BloomFilter::DeserializeFromDisk(const std::string &filename)
+{
+    std::ifstream in_file(filename, std::ios::binary);
+    in_file.read(reinterpret_cast<char *>(&num_bits_), sizeof(num_bits_));
+    in_file.read(reinterpret_cast<char *>(&num_hashes_), sizeof(num_hashes_));
+    bit_array_.resize(num_bits_);
+    for (size_t i = 0; i < num_bits_; ++i)
+    {
+        bool bit;
+        in_file.read(reinterpret_cast<char *>(&bit), sizeof(bit));
+        bit_array_[i] = bit;
+    }
+    in_file.close();
 }
 
-void BloomFilter::Union(const BloomFilter& other) {
-    if (num_bits_ != other.num_bits_ || num_hashes_ != other.num_hashes_) {
-        throw std::invalid_argument("Cannot union Bloom filters with different sizes or hash functions");
+void
+BloomFilter::Union(const BloomFilter &other)
+{
+    if (num_bits_ != other.num_bits_ || num_hashes_ != other.num_hashes_)
+    {
+        throw std::invalid_argument(
+            "Cannot union Bloom filters with different sizes or hash "
+            "functions");
     }
 
-    for (size_t i = 0; i < num_bits_; ++i) {
+    for (size_t i = 0; i < num_bits_; ++i)
+    {
         bit_array_[i] = bit_array_[i] || other.bit_array_[i];
     }
 }

--- a/src/bloom_filter/bloom_filter.h
+++ b/src/bloom_filter/bloom_filter.h
@@ -1,20 +1,22 @@
-#pragma once // ensure the header file is included only once during compilation.
-#include <vector>
+#pragma once  // ensure the header file is included only once during
+              // compilation.
 #include <cmath>
 #include <string>
+#include <vector>
 
-class BloomFilter {
- public:
-  BloomFilter(size_t num_bits, size_t num_hashes);
-  void Insert(int key);
-  bool MayContain(int key) const;
-  void SerializeToDisk(const std::string &filename) const;
-  void DeserializeFromDisk(const std::string &filename);
-  void Union(const BloomFilter& other);
+class BloomFilter
+{
+   public:
+    BloomFilter(size_t num_bits, size_t num_hashes);
+    void Insert(int key);
+    bool MayContain(int key) const;
+    void SerializeToDisk(const std::string &filename) const;
+    void DeserializeFromDisk(const std::string &filename);
+    void Union(const BloomFilter &other);
 
- private:
-  size_t Hash(int key, int seed) const;
-  std::vector<bool> bit_array_;
-  size_t num_hashes_;
-  size_t num_bits_;
+   private:
+    size_t Hash(int key, int seed) const;
+    std::vector<bool> bit_array_;
+    size_t num_hashes_;
+    size_t num_bits_;
 };

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -287,7 +287,7 @@ Database::Compact()
     merged_filter.Union(bloom_filter2);
 
     // Serialize the merged Bloom filter to disk
-    merged_filter.SerializeToDisk(out_file + ".filter");
+    merged_filter.SerializeToDisk(db_name_ + "/" + out_file + ".filter");
 
     // remove the merged files
     std::filesystem::remove(filename1);

--- a/src/include/common/config.h
+++ b/src/include/common/config.h
@@ -1,5 +1,5 @@
+#include <climits>  // INT_MAX
 #include <cstdint>
-#include <climits> // INT_MAX
 
 using frame_id_t = int32_t;  // frame id type
 using page_id_t = int32_t;   // page id type

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,13 @@
 #include <unistd.h>
+
 #include <filesystem>
+
 #include "database.h"
 #include "include/common/config.h"
 
-int main() {
+int
+main()
+{
     std::filesystem::remove_all("db");
     Database db("db", MEMTABLE_SIZE);
     db.Open();
@@ -15,7 +19,8 @@ int main() {
     db.Put(2, 20);
 
     // Add 300000 keys
-    for (int i = 2; i < 7000000; i++) {
+    for (int i = 2; i < 7000000; i++)
+    {
         db.Put(i, i * 10);
     }
 
@@ -26,7 +31,8 @@ int main() {
     printf("Get 1 after delete: %d\n", db.Get(1));
 
     // Add 300000 more keys
-    for (int i = 300002; i < 600002; i++) {
+    for (int i = 300002; i < 600002; i++)
+    {
         db.Put(i, i * 10);
     }
 

--- a/src/memtable.cpp
+++ b/src/memtable.cpp
@@ -2,11 +2,7 @@
 
 #include "include/common/config.h"
 
-Memtable::Memtable(int memtable_size) : max_size_(memtable_size / 8)
-{
-    printf("Memtable size: %d MB\n", memtable_size / 1024 / 1024);
-    printf("Max number of key-value pairs: %d\n", max_size_);
-}
+Memtable::Memtable(int memtable_size) : max_size_(memtable_size / 8) {}
 
 /* Insert a KV pair into the memtable. */
 void

--- a/src/sst.cpp
+++ b/src/sst.cpp
@@ -7,11 +7,16 @@
 #include <fstream>
 #include <stdexcept>
 
-SSTable::SSTable(const std::string& path) : file_path(path), bloom_filter(1024, 3) {
+SSTable::SSTable(const std::string& path)
+    : file_path(path), bloom_filter(1024, 3)
+{
     struct stat buf;
-    if (stat(file_path.c_str(), &buf) != 0) {
+    if (stat(file_path.c_str(), &buf) != 0)
+    {
         throw std::runtime_error("Failed to stat SSTable file");
-    } else {
+    }
+    else
+    {
         // Dividing the file size by the size of one kv pair.
         num_entries = buf.st_size / (sizeof(int) * 2);
 
@@ -21,41 +26,52 @@ SSTable::SSTable(const std::string& path) : file_path(path), bloom_filter(1024, 
     }
 }
 
-int SSTable::readKey(int fd, off_t offset) {
+int
+SSTable::readKey(int fd, off_t offset)
+{
     int key;
-    if (pread(fd, &key, sizeof(int), offset) != sizeof(int)) {
+    if (pread(fd, &key, sizeof(int), offset) != sizeof(int))
+    {
         throw std::runtime_error("Failed to read key from SSTable");
     }
     return key;
 }
 
-int SSTable::readValue(int fd, off_t offset) {
+int
+SSTable::readValue(int fd, off_t offset)
+{
     int value;
-    if (pread(fd, &value, sizeof(int), offset) != sizeof(int)) {
+    if (pread(fd, &value, sizeof(int), offset) != sizeof(int))
+    {
         throw std::runtime_error("Failed to read value from SSTable");
     }
     return value;
 }
 /* Use a binary search to find the start of the range and continue with a scan
   until encounter a key key outside of the range. */
-std::vector<std::pair<int, int>> SSTable::scan(int key1, int key2) {
+std::vector<std::pair<int, int>>
+SSTable::scan(int key1, int key2)
+{
     std::vector<std::pair<int, int>> result;
 
     // Check if any keys in the range might exist using the Bloom filter
     bool may_contain = false;
-    for (int key = key1; key <= key2; ++key) {
-        if (bloom_filter.MayContain(key)) {
+    for (int key = key1; key <= key2; ++key)
+    {
+        if (bloom_filter.MayContain(key))
+        {
             may_contain = true;
             break;
         }
     }
-    if (!may_contain) {
-        printf("Bloom filter indicates no keys in range [%d, %d]\n", key1, key2);
+    if (!may_contain)
+    {
         return result;  // Skip scanning the SST
     }
 
     int fd = open(file_path.c_str(), O_RDONLY);
-    if (fd < 0) {
+    if (fd < 0)
+    {
         throw std::runtime_error("Failed to open SSTable file");
     }
 
@@ -64,21 +80,26 @@ std::vector<std::pair<int, int>> SSTable::scan(int key1, int key2) {
     size_t right = num_entries - 1;
     size_t start_pos = num_entries;
 
-    while (left <= right) {
+    while (left <= right)
+    {
         size_t mid = (left + right) / 2;
         off_t ofs = mid * sizeof(int) * 2;
         int key = readKey(fd, ofs);
 
-        if (key < key1) {
+        if (key < key1)
+        {
             left = mid + 1;
-        } else {
+        }
+        else
+        {
             right = mid - 1;
             start_pos = mid;
         }
     }
 
     // Sequentially read from start position
-    for (size_t i = start_pos; i < num_entries; i++) {
+    for (size_t i = start_pos; i < num_entries; i++)
+    {
         off_t ofs = i * sizeof(int) * 2;
         int key = readKey(fd, ofs);
         if (key > key2) break;
@@ -90,15 +111,22 @@ std::vector<std::pair<int, int>> SSTable::scan(int key1, int key2) {
     return result;
 }
 
-int SSTable::get(int key) {
+int
+SSTable::get(int key)
+{
     // Use the Bloom filter to check if the key might exist
-    static bool bloom_filter_message_printed = false;  // Flag to track message printing
+    static bool bloom_filter_message_printed =
+        false;  // Flag to track message printing
 
     // Check the Bloom filter before accessing the SST
-    if (!bloom_filter.MayContain(key)) {
-        if (!bloom_filter_message_printed) {
-            printf("Key %d is definitely not in %s (skipped using Bloom filter)\n", key, file_path.c_str());
-            bloom_filter_message_printed = true; 
+    if (!bloom_filter.MayContain(key))
+    {
+        if (!bloom_filter_message_printed)
+        {
+            printf(
+                "Key %d is definitely not in %s (skipped using Bloom filter)\n",
+                key, file_path.c_str());
+            bloom_filter_message_printed = true;
         }
         return -1;  // Skip searching the SST
     }
@@ -109,18 +137,24 @@ int SSTable::get(int key) {
     size_t left = 0;
     size_t right = num_entries - 1;
 
-    while (left <= right) {
+    while (left <= right)
+    {
         size_t mid = left + (right - left) / 2;
         off_t ofs = mid * sizeof(int) * 2;
         int mid_key = readKey(fd, ofs);
 
-        if (mid_key == key) {
+        if (mid_key == key)
+        {
             int value = readValue(fd, ofs + sizeof(int));
             close(fd);
             return value;
-        } else if (mid_key < key) {
+        }
+        else if (mid_key < key)
+        {
             left = mid + 1;
-        } else {
+        }
+        else
+        {
             right = mid - 1;
         }
     }
@@ -129,19 +163,27 @@ int SSTable::get(int key) {
     return -1;  // Key not found
 }
 
-void SSTable::write(const std::string& filename, const std::vector<std::pair<int, int>>& data) {
+void
+SSTable::write(const std::string& filename,
+               const std::vector<std::pair<int, int>>& data)
+{
     std::ofstream outFile(filename, std::ios::binary);
-    if (!outFile.is_open()) {
+    if (!outFile.is_open())
+    {
         throw std::runtime_error("Failed to create SST file: " + filename);
     }
 
     // Create a Bloom filter for the keys
-    BloomFilter bloom_filter(data.size() * 10, 3);  // 10 bits per entry, 3 hash functions
+    BloomFilter bloom_filter(data.size() * 10,
+                             3);  // 10 bits per entry, 3 hash functions
 
     // Write each key-value pair to the file
-    for (const auto& kv : data) {
-        outFile.write(reinterpret_cast<const char*>(&kv.first), sizeof(kv.first));
-        outFile.write(reinterpret_cast<const char*>(&kv.second), sizeof(kv.second));
+    for (const auto& kv : data)
+    {
+        outFile.write(reinterpret_cast<const char*>(&kv.first),
+                      sizeof(kv.first));
+        outFile.write(reinterpret_cast<const char*>(&kv.second),
+                      sizeof(kv.second));
         bloom_filter.Insert(kv.first);  // Add the key to the Bloom filter
     }
 

--- a/src/sst.h
+++ b/src/sst.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "./bloom_filter/bloom_filter.h"
 
 /** Sorted String Table (SSTable) class.
@@ -18,7 +19,7 @@ class SSTable
    private:
     std::string file_path;
     size_t num_entries;
-    BloomFilter bloom_filter; 
+    BloomFilter bloom_filter;
 
     int readKey(int fd, off_t offset);
     int readValue(int fd, off_t offset);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -22,12 +22,13 @@ AssertEqual(int expected, int actual, const char *testName, int &testsPassed,
 {
     if (expected == actual)
     {
-        printf("PASSED: %s\n", testName);
+        printf("    PASSED: %s\n", testName);
         testsPassed++;
     }
     else
     {
-        printf("%s: FAILED: expected %d, got %d\n", testName, expected, actual);
+        printf("    %s: FAILED: expected %d, got %d\n", testName, expected,
+               actual);
         testsFailed++;
     }
 }
@@ -133,19 +134,22 @@ TestAvlTreeScan(int &totalPassed, int &totalFailed)
 }
 
 void
-TestAvlTree()
+TestAvlTree(int &overallPassed, int &overallFailed)
 {
     int totalTestsPassed = 0;
     int totalTestsFailed = 0;
 
-    printf("AVL TREE TESTS:\n");
+    printf("AVL TREE TESTS:");
     TestAvlTreeInsert(totalTestsPassed, totalTestsFailed);
     TestAvlTreeGet(totalTestsPassed, totalTestsFailed);
     TestAvlTreeScan(totalTestsPassed, totalTestsFailed);
 
-    printf("\n\nTEST SUMMARY\n");
-    printf("Passed: %d\n", totalTestsPassed);
-    printf("Failed: %d\n", totalTestsFailed);
+    printf("\n  SUMMARY\n");
+    printf("    PASSED: %d\n", totalTestsPassed);
+    printf("    FAILED: %d\n", totalTestsFailed);
+
+    overallPassed += totalTestsPassed;
+    overallFailed += totalTestsFailed;
 }
 
 /*
@@ -157,7 +161,7 @@ TestAvlTree()
 void
 TestDatabaseOpenClose(int &totalPassed, int &totalFailed)
 {
-    printf("\n\nDATABASE OPEN & CLOSE TESTS\n");
+    printf("\n  OPEN & CLOSE\n");
     Database db("test_db", MEMTABLE_SIZE);
     int testsPassed = 0;
     int testsFailed = 0;
@@ -181,7 +185,7 @@ TestDatabaseOpenClose(int &totalPassed, int &totalFailed)
 void
 TestDatabasePutGet(int &totalPassed, int &totalFailed)
 {
-    printf("\n\nDATABASE PUT & GET TESTS\n");
+    printf("\n  PUT & GET\n");
     Database db("test_db", MEMTABLE_SIZE);
     db.Open();
     int testsPassed = 0;
@@ -204,7 +208,7 @@ TestDatabasePutGet(int &totalPassed, int &totalFailed)
 void
 TestDatabaseScan(int &totalPassed, int &totalFailed)
 {
-    printf("\n\nDATABASE SCAN TESTS\n");
+    printf("\n  SCAN\n");
     Database db("test_db", MEMTABLE_SIZE);
     db.Open();
     int testsPassed = 0;
@@ -230,19 +234,22 @@ TestDatabaseScan(int &totalPassed, int &totalFailed)
 }
 
 void
-TestDatabase()
+TestDatabase(int &overallPassed, int &overallFailed)
 {
     int totalTestsPassed = 0;
     int totalTestsFailed = 0;
 
-    printf("DATABASE TESTS:\n");
+    printf("\nDATABASE TESTS:");
     TestDatabaseOpenClose(totalTestsPassed, totalTestsFailed);
     TestDatabasePutGet(totalTestsPassed, totalTestsFailed);
     TestDatabaseScan(totalTestsPassed, totalTestsFailed);
 
-    printf("\n\nDATABASE TEST SUMMARY\n");
-    printf("Passed: %d\n", totalTestsPassed);
-    printf("Failed: %d\n", totalTestsFailed);
+    printf("\n  SUMMARY\n");
+    printf("    PASSED: %d\n", totalTestsPassed);
+    printf("    FAILED: %d\n", totalTestsFailed);
+
+    overallPassed += totalTestsPassed;
+    overallFailed += totalTestsFailed;
 }
 
 /*
@@ -253,7 +260,7 @@ TestDatabase()
 void
 TestConvertMemtableToBTree(int &totalPassed, int &totalFailed)
 {
-    printf("\n\nMEMTABLE TO BTREE TESTS\n");
+    printf("\n  MEMTABLE TO BTREE\n");
     // the memtable turns into a sorted list of key-value pairs. So make a mock
     // one here
     std::vector<std::pair<int, int>> data;
@@ -269,17 +276,17 @@ TestConvertMemtableToBTree(int &totalPassed, int &totalFailed)
     auto internal_pages = btree.GetInternalPages();
 
     // check that there is 1 of each
-    AssertEqual(1, leaf_pages.size(), "1 leaf page created", totalPassed,
+    AssertEqual(1, leaf_pages.size(), "Create 1 leaf page", totalPassed,
                 totalFailed);
-    AssertEqual(1, internal_pages.size(), "1 internal page created",
-                totalPassed, totalFailed);
+    AssertEqual(1, internal_pages.size(), "Create 1 internal page", totalPassed,
+                totalFailed);
 
     // check that the leaf page has 100 key-value pairs and the internal page
     // has 1 key-value pair
     AssertEqual(100, leaf_pages[0].GetSize(),
-                "leaf page has 100 key-value pairs", totalPassed, totalFailed);
+                "Leaf page has 100 key-value pairs", totalPassed, totalFailed);
     AssertEqual(1, internal_pages[0].GetSize(),
-                "internal page has 1 key-value pair", totalPassed, totalFailed);
+                "Internal page has 1 key-value pair", totalPassed, totalFailed);
 
     // check that every key in leaf page is <= the key in the internal page
     int passed = 1;
@@ -299,7 +306,7 @@ TestConvertMemtableToBTree(int &totalPassed, int &totalFailed)
 void
 TestBTreeFiles(int &totalPassed, int &totalFailed)
 {
-    printf("\n\nBTREE FILE TESTS\n");
+    printf("\n  BTREE FILE\n");
     // make a test_db directory. Input 125k kv pairs into the db.
     // Input another 125k kv pairs into the db. this will trigger a merge.
 
@@ -425,24 +432,34 @@ TestBTreeFiles(int &totalPassed, int &totalFailed)
 }
 
 void
-BTreeTests()
+BTreeTests(int &overallPassed, int &overallFailed)
 {
     int totalPassed = 0;
     int totalFailed = 0;
 
+    printf("\n\nBTREE TESTS:");
     TestConvertMemtableToBTree(totalPassed, totalFailed);
     TestBTreeFiles(totalPassed, totalFailed);
 
-    printf("\n\nBTREE TEST SUMMARY\n");
-    printf("Passed: %d\n", totalPassed);
-    printf("Failed: %d\n", totalFailed);
+    printf("\n  SUMMARY\n");
+    printf("    PASSED: %d\n", totalPassed);
+    printf("    FAILED: %d\n", totalFailed);
+
+    overallPassed += totalPassed;
+    overallFailed += totalFailed;
 }
 
 int
 main()
 {
-    TestAvlTree();
-    TestDatabase();
-    BTreeTests();
+    int overallPassed = 0;
+    int overallFailed = 0;
+    TestAvlTree(overallPassed, overallFailed);
+    TestDatabase(overallPassed, overallFailed);
+    BTreeTests(overallPassed, overallFailed);
+
+    printf("\n\nOVERALL\n");
+    printf("  PASSED: %d\n", overallPassed);
+    printf("  FAILED: %d\n", overallFailed);
     return 0;
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -5,15 +5,24 @@
 #include <filesystem>
 
 #include "../src/avl_tree.h"
+#include "../src/b_tree/b_tree.h"
+#include "../src/b_tree/b_tree_manager.h"
+#include "../src/b_tree/b_tree_page.h"
 #include "../src/database.h"
+#include "../src/include/common/config.h"
 
+/*
+
+    Helper Functions
+
+ */
 void
-assertEqual(int expected, int actual, const char *testName, int &testsPassed,
+AssertEqual(int expected, int actual, const char *testName, int &testsPassed,
             int &testsFailed)
 {
     if (expected == actual)
     {
-        printf("%s: PASSED\n", testName);
+        printf("PASSED: %s\n", testName);
         testsPassed++;
     }
     else
@@ -23,8 +32,13 @@ assertEqual(int expected, int actual, const char *testName, int &testsPassed,
     }
 }
 
+/*
+
+    AVL Tree Tests
+
+*/
 void
-testAVLTreeInsert(int &totalPassed, int &totalFailed)
+TestAvlTreeInsert(int &totalPassed, int &totalFailed)
 {
     printf("\n\nINSERT TESTS\n");
     AVLTree tree;
@@ -32,15 +46,15 @@ testAVLTreeInsert(int &totalPassed, int &totalFailed)
     int testsFailed = 0;
 
     printf(" INSERTING VALUES\n");
-    tree.put(10, 100);
-    tree.put(20, 200);
-    tree.put(30, 300);
+    tree.insert(10, 100);
+    tree.insert(20, 200);
+    tree.insert(30, 300);
 
-    assertEqual(100, tree.get(10), "  10 exists after insert", testsPassed,
+    AssertEqual(100, tree.search(10), "  10 exists after insert", testsPassed,
                 testsFailed);
-    assertEqual(200, tree.get(20), "  20 exists after insert", testsPassed,
+    AssertEqual(200, tree.search(20), "  20 exists after insert", testsPassed,
                 testsFailed);
-    assertEqual(300, tree.get(30), "  30 exists after insert", testsPassed,
+    AssertEqual(300, tree.search(30), "  30 exists after insert", testsPassed,
                 testsFailed);
 
     totalPassed += testsPassed;
@@ -48,7 +62,7 @@ testAVLTreeInsert(int &totalPassed, int &totalFailed)
 }
 
 void
-testAVLTreeGet(int &totalPassed, int &totalFailed)
+TestAvlTreeGet(int &totalPassed, int &totalFailed)
 {
     printf("\n\nGET TESTS\n");
     AVLTree tree;
@@ -56,16 +70,19 @@ testAVLTreeGet(int &totalPassed, int &totalFailed)
     int testsFailed = 0;
 
     printf(" INSERTING VALUES\n");
-    tree.put(10, 100);
-    tree.put(20, 200);
-    tree.put(30, 300);
+    tree.insert(10, 100);
+    tree.insert(20, 200);
+    tree.insert(30, 300);
 
-    assertEqual(100, tree.get(10), "  Test get(10)", testsPassed, testsFailed);
-    assertEqual(200, tree.get(20), "  Test get(20)", testsPassed, testsFailed);
-    assertEqual(300, tree.get(30), "  Test get(30)", testsPassed, testsFailed);
+    AssertEqual(100, tree.search(10), "  Test get(10)", testsPassed,
+                testsFailed);
+    AssertEqual(200, tree.search(20), "  Test get(20)", testsPassed,
+                testsFailed);
+    AssertEqual(300, tree.search(30), "  Test get(30)", testsPassed,
+                testsFailed);
 
     // Test non-existent key
-    assertEqual(-1, tree.get(40), "  return -1 for non-existent key",
+    AssertEqual(-1, tree.search(40), "  return -1 for non-existent key",
                 testsPassed, testsFailed);
 
     totalPassed += testsPassed;
@@ -73,7 +90,7 @@ testAVLTreeGet(int &totalPassed, int &totalFailed)
 }
 
 void
-testAVLTreeScan(int &totalPassed, int &totalFailed)
+TestAvlTreeScan(int &totalPassed, int &totalFailed)
 {
     printf("\n\nSCAN TESTS\n");
     AVLTree tree;
@@ -82,33 +99,33 @@ testAVLTreeScan(int &totalPassed, int &totalFailed)
 
     printf(" SCAN ON EMPTY TREE\n");
     auto result = tree.scan(1, 10);
-    assertEqual(0, result.size(), "  results size is 0", testsPassed,
+    AssertEqual(0, result.size(), "  results size is 0", testsPassed,
                 testsFailed);
 
     printf(" SCAN OUT OF RANGE\n");
-    tree.put(10, 100);
-    tree.put(20, 200);
-    tree.put(30, 300);
+    tree.insert(10, 100);
+    tree.insert(20, 200);
+    tree.insert(30, 300);
     result = tree.scan(40, 50);
-    assertEqual(0, result.size(), "  results size is 0", testsPassed,
+    AssertEqual(0, result.size(), "  results size is 0", testsPassed,
                 testsFailed);
 
     printf(" SCAN FOR ALL RESULTS\n");
     result = tree.scan(5, 35);
-    assertEqual(3, result.size(), "  results size is 3", testsPassed,
+    AssertEqual(3, result.size(), "  results size is 3", testsPassed,
                 testsFailed);
-    assertEqual(100, result[0].second, "  key 10 exists", testsPassed,
+    AssertEqual(100, result[0].second, "  key 10 exists", testsPassed,
                 testsFailed);
-    assertEqual(200, result[1].second, "  key 20 exists", testsPassed,
+    AssertEqual(200, result[1].second, "  key 20 exists", testsPassed,
                 testsFailed);
-    assertEqual(300, result[2].second, "  key 30 exists", testsPassed,
+    AssertEqual(300, result[2].second, "  key 30 exists", testsPassed,
                 testsFailed);
 
     printf(" SCAN FOR PARTIAL RESULTS\n");
     result = tree.scan(15, 25);
-    assertEqual(1, result.size(), "  results size is 1", testsPassed,
+    AssertEqual(1, result.size(), "  results size is 1", testsPassed,
                 testsFailed);
-    assertEqual(200, result[0].second, "  key 20 exists", testsPassed,
+    AssertEqual(200, result[0].second, "  key 20 exists", testsPassed,
                 testsFailed);
 
     totalPassed += testsPassed;
@@ -116,73 +133,56 @@ testAVLTreeScan(int &totalPassed, int &totalFailed)
 }
 
 void
-testAVLTree()
+TestAvlTree()
 {
     int totalTestsPassed = 0;
     int totalTestsFailed = 0;
 
     printf("AVL TREE TESTS:\n");
-    testAVLTreeInsert(totalTestsPassed, totalTestsFailed);
-    testAVLTreeGet(totalTestsPassed, totalTestsFailed);
-    testAVLTreeScan(totalTestsPassed, totalTestsFailed);
+    TestAvlTreeInsert(totalTestsPassed, totalTestsFailed);
+    TestAvlTreeGet(totalTestsPassed, totalTestsFailed);
+    TestAvlTreeScan(totalTestsPassed, totalTestsFailed);
 
     printf("\n\nTEST SUMMARY\n");
     printf("Passed: %d\n", totalTestsPassed);
     printf("Failed: %d\n", totalTestsFailed);
 }
 
-// Test Open and Close
+/*
+
+    Database Tests
+
+*/
+
 void
-testDatabaseOpenClose(int &totalPassed, int &totalFailed)
+TestDatabaseOpenClose(int &totalPassed, int &totalFailed)
 {
     printf("\n\nDATABASE OPEN & CLOSE TESTS\n");
-    Database db("test_db", 5);
+    Database db("test_db", MEMTABLE_SIZE);
     int testsPassed = 0;
     int testsFailed = 0;
 
     // Test Open
     db.Open();
-    assertEqual(1, directoryExists("test_db"), "Database directory created",
+    struct stat buffer;
+    AssertEqual(0, stat("test_db", &buffer), "Database directory exists",
                 testsPassed, testsFailed);
 
     // Test Close without data in memtable
     db.Close();
-    assertEqual(1, db.Get(0) == -1, "Database closed and no data persists",
+    AssertEqual(1, db.Get(0) == -1, "Database closed and no data persists",
                 testsPassed, testsFailed);
 
     totalPassed += testsPassed;
     totalFailed += testsFailed;
+    std::filesystem::remove_all("test_db");
 }
 
-// Test StoreMemtable functionality
 void
-testDatabaseStoreMemtable(int &totalPassed, int &totalFailed)
-{
-    printf("\n\nDATABASE STORE MEMTABLE TESTS\n");
-    Database db("test_db", 2);  // Low memtable size for quick flush
-    db.Open();
-    int testsPassed = 0;
-    int testsFailed = 0;
-
-    db.Put(10, 1000);
-    db.Put(20, 2000);
-
-    // Fill memtable to trigger store
-    db.Put(30, 3000);
-    assertEqual(3000, db.Get(30), "Data from new Memtable after flush",
-                testsPassed, testsFailed);
-
-    db.Close();
-    totalPassed += testsPassed;
-    totalFailed += testsFailed;
-}
-
-// Test Put and Get functionality
-void
-testDatabasePutGet(int &totalPassed, int &totalFailed)
+TestDatabasePutGet(int &totalPassed, int &totalFailed)
 {
     printf("\n\nDATABASE PUT & GET TESTS\n");
-    Database db("test_db", 5);
+    Database db("test_db", MEMTABLE_SIZE);
     db.Open();
     int testsPassed = 0;
     int testsFailed = 0;
@@ -190,21 +190,22 @@ testDatabasePutGet(int &totalPassed, int &totalFailed)
     db.Put(1, 100);
     db.Put(2, 200);
     db.Put(3, 300);
-    assertEqual(100, db.Get(1), "Database get(1)", testsPassed, testsFailed);
-    assertEqual(200, db.Get(2), "Database get(2)", testsPassed, testsFailed);
-    assertEqual(300, db.Get(3), "Database get(3)", testsPassed, testsFailed);
+    AssertEqual(100, db.Get(1), "Database get(1)", testsPassed, testsFailed);
+    AssertEqual(200, db.Get(2), "Database get(2)", testsPassed, testsFailed);
+    AssertEqual(300, db.Get(3), "Database get(3)", testsPassed, testsFailed);
 
     db.Close();
     totalPassed += testsPassed;
     totalFailed += testsFailed;
+
+    std::filesystem::remove_all("test_db");
 }
 
-// Test Scan functionality
 void
-testDatabaseScan(int &totalPassed, int &totalFailed)
+TestDatabaseScan(int &totalPassed, int &totalFailed)
 {
     printf("\n\nDATABASE SCAN TESTS\n");
-    Database db("test_db", 3);  // Memtable threshold 3
+    Database db("test_db", MEMTABLE_SIZE);
     db.Open();
     int testsPassed = 0;
     int testsFailed = 0;
@@ -217,36 +218,231 @@ testDatabaseScan(int &totalPassed, int &totalFailed)
     db.Put(5, 500);
 
     auto scanResults = db.Scan(2, 5);
-    assertEqual(4, scanResults.size(), "Scan results within range 2 to 5",
+    AssertEqual(4, scanResults.size(), "Scan results within range 2 to 5",
                 testsPassed, testsFailed);
 
     db.Close();
     totalPassed += testsPassed;
     totalFailed += testsFailed;
+
+    // Clean up
+    std::filesystem::remove_all("test_db");
 }
 
-// New master test function for Database
 void
-testDatabase()
+TestDatabase()
 {
     int totalTestsPassed = 0;
     int totalTestsFailed = 0;
 
     printf("DATABASE TESTS:\n");
-    testDatabaseOpenClose(totalTestsPassed, totalTestsFailed);
-    testDatabaseStoreMemtable(totalTestsPassed, totalTestsFailed);
-    testDatabasePutGet(totalTestsPassed, totalTestsFailed);
-    testDatabaseScan(totalTestsPassed, totalTestsFailed);
+    TestDatabaseOpenClose(totalTestsPassed, totalTestsFailed);
+    TestDatabasePutGet(totalTestsPassed, totalTestsFailed);
+    TestDatabaseScan(totalTestsPassed, totalTestsFailed);
 
     printf("\n\nDATABASE TEST SUMMARY\n");
     printf("Passed: %d\n", totalTestsPassed);
     printf("Failed: %d\n", totalTestsFailed);
 }
 
+/*
+
+    BTree Tests
+
+*/
+void
+TestConvertMemtableToBTree(int &totalPassed, int &totalFailed)
+{
+    printf("\n\nMEMTABLE TO BTREE TESTS\n");
+    // the memtable turns into a sorted list of key-value pairs. So make a mock
+    // one here
+    std::vector<std::pair<int, int>> data;
+    // add 100 key-value pairs
+    for (int i = 0; i < 100; i++)
+    {
+        data.push_back({i, i * 10});
+    }
+    // the constructor will convert the data into a btree
+    BTree btree(data);
+
+    auto leaf_pages = btree.GetLeafPages();
+    auto internal_pages = btree.GetInternalPages();
+
+    // check that there is 1 of each
+    AssertEqual(1, leaf_pages.size(), "1 leaf page created", totalPassed,
+                totalFailed);
+    AssertEqual(1, internal_pages.size(), "1 internal page created",
+                totalPassed, totalFailed);
+
+    // check that the leaf page has 100 key-value pairs and the internal page
+    // has 1 key-value pair
+    AssertEqual(100, leaf_pages[0].GetSize(),
+                "leaf page has 100 key-value pairs", totalPassed, totalFailed);
+    AssertEqual(1, internal_pages[0].GetSize(),
+                "internal page has 1 key-value pair", totalPassed, totalFailed);
+
+    // check that every key in leaf page is <= the key in the internal page
+    int passed = 1;
+    for (auto pair : leaf_pages[0].GetKeyValues())
+    {
+        if (pair.first > internal_pages[0].GetKeyValues()[0].first)
+        {
+            passed = 0;
+            break;
+        }
+    }
+
+    AssertEqual(1, passed, "Keys in leaf page <= Key in internal parent",
+                totalPassed, totalFailed);
+}
+
+void
+TestBTreeFiles(int &totalPassed, int &totalFailed)
+{
+    printf("\n\nBTREE FILE TESTS\n");
+    // make a test_db directory. Input 125k kv pairs into the db.
+    // Input another 125k kv pairs into the db. this will trigger a merge.
+
+    // input 125k kv pairs into the db
+    Database db("test_db", MEMTABLE_SIZE);
+    db.Open();
+    for (int i = 0; i < 135000; i++)
+    {
+        db.Put(i, i * 10);
+    }
+
+    // read the test_db directory, store the list of files
+    std::vector<std::string> files;
+    for (const auto &entry : std::filesystem::directory_iterator("test_db"))
+    {
+        if (entry.path().extension() != ".filter")
+        {
+            files.push_back(entry.path().string());
+        }
+    }
+
+    // check that there is one .sst file with _0000_ in the name
+    int sst_files = 0;
+    for (auto file : files)
+    {
+        if (file.find("sst_0000_") != std::string::npos)
+        {
+            sst_files++;
+        }
+    }
+    AssertEqual(1, sst_files, "Create a BTree file upon filling Memtable",
+                totalPassed, totalFailed);
+
+    // test get and scan over btree files
+    AssertEqual(30, db.Get(3), "Get a key from from within a BTree file",
+                totalPassed, totalFailed);
+    auto scanResults = db.Scan(2, 5);
+    AssertEqual(4, scanResults.size(), "Scan a range within a BTree file",
+                totalPassed, totalFailed);
+
+    // update a key in the db
+    db.Put(1, 100);
+    // delete a key from the db
+    db.Delete(2);
+
+    // input another 135k kv pairs into the db
+    for (int i = 135000; i < 270000; i++)
+    {
+        db.Put(i, i * 10);
+    }
+
+    // read the test_db directory, store the list of files
+    files.clear();
+    for (const auto &entry : std::filesystem::directory_iterator("test_db"))
+    {
+        if (entry.path().extension() != ".filter")
+        {
+            files.push_back(entry.path().string());
+        }
+    }
+
+    // check that there is one .sst file with _0001_ in the name
+    sst_files = 0;
+    std::string filename;
+    for (auto file : files)
+    {
+        if (file.find("sst_0001_") != std::string::npos)
+        {
+            sst_files++;
+            filename = file;
+        }
+    }
+    AssertEqual(1, sst_files, "Merge 2 BTree files into a new level",
+                totalPassed, totalFailed);
+
+    // load in the merged btree file and check for the updated value
+    BTreeManager btm(filename, 1);
+    BTreePage page = btm.TraverseToKey(1);
+    AssertEqual(100, page.Get(1), "Update a key", totalPassed, totalFailed);
+
+    // check that the deleted key is not in the btree
+    page = btm.TraverseToKey(2);
+    AssertEqual(-1, page.Get(2),
+                "Remove a tombstone when merging into a new level", totalPassed,
+                totalFailed);
+
+    // insert another 125k kv pairs into the db
+    for (int i = 270000; i < 395000; i++)
+    {
+        db.Put(i, i * 10);
+    }
+
+    // ensure there are 2 files, one level 0000 and one level 0001
+    files.clear();
+    for (const auto &entry : std::filesystem::directory_iterator("test_db"))
+    {
+        if (entry.path().extension() != ".filter")
+        {
+            files.push_back(entry.path().string());
+        }
+    }
+
+    sst_files = 0;
+    for (auto file : files)
+    {
+        if (file.find("sst_0000_") != std::string::npos ||
+            file.find("sst_0001_") != std::string::npos)
+        {
+            sst_files++;
+        }
+    }
+
+    AssertEqual(2, sst_files, "Save 2 levels of BTree files", totalPassed,
+                totalFailed);
+
+    // scan across 2 files
+    scanResults = db.Scan(0, 395000);
+    AssertEqual(395000 - 1, scanResults.size(), "Scan across 2 BTree files",
+                totalPassed, totalFailed);
+
+    db.Close();
+    std::filesystem::remove_all("test_db");
+}
+
+void
+BTreeTests()
+{
+    int totalPassed = 0;
+    int totalFailed = 0;
+
+    TestConvertMemtableToBTree(totalPassed, totalFailed);
+    TestBTreeFiles(totalPassed, totalFailed);
+
+    printf("\n\nBTREE TEST SUMMARY\n");
+    printf("Passed: %d\n", totalPassed);
+    printf("Failed: %d\n", totalFailed);
+}
+
 int
 main()
 {
-    testAVLTree();
-    testDatabase();
+    TestAvlTree();
+    TestDatabase();
+    BTreeTests();
     return 0;
 }


### PR DESCRIPTION
The bloom filter tweaks are 

1. Remove bloom filter use for scans.
2. Point the output location of merged bloom filters to the db directory rather than the root directory.